### PR TITLE
Allow doctrine/orm:^2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/common": "^3.3",
         "doctrine/persistence": "^2.5|^3.0",
         "doctrine/dbal": "^3.8.0",
-        "doctrine/orm": "^3.0.0",
+        "doctrine/orm": "^2.12|^3.0.0",
         "doctrine/doctrine-bundle": "^2.7.2",
         "symfony/cache": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
Hello, this PR restores doctrine/orm:^2.12 compatibility, still needed for some projects.