### PR TITLE
allow Symfony 7.1 beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/cache": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "symfony/http-kernel": "^5.4|^6.0|^7.0",
-        "symfony/security-bundle": "^5.4|^6.0|7.0.*",
+        "symfony/security-bundle": "^5.4|^6.0|^7.0",
         "symfony/framework-bundle": "^5.4|^6.0|^7.0",
         "symfony/string": "^5.4|^6.0|^7.0",
         "symfony/translation-contracts": "^2.4|^3.0",


### PR DESCRIPTION
Actually, I'm not sure if this will allow Symfony 7.1 beta, but certainly with a 7.1 release close there's no reason to lock this bundle to 7.0.*