### PR TITLE
allow doctrine/orm version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/common": "^3.3",
         "doctrine/persistence": "^2.5|^3.0",
         "doctrine/dbal": "^3.8.0",
-        "doctrine/orm": "^3.0.0",
+        "doctrine/orm": "^2.19|^3.0.0",
         "doctrine/doctrine-bundle": "^2.7.2",
         "symfony/cache": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
I have another bundle that requires doctrine/orm 2, and can't install this with it.  I don't think there's anything that is orm:^3-specific in this bundle.